### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: 
+repo_types: [Experiment]
+platforms: [PUBLIC_CLOUD (Azure)]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "DOK.Arealanalyse.demonstrator"
+  tags: []
+spec:
+  type: "experiment"
+  lifecycle: "experiment"
+  owner: "datadeling_og_distribusjon"
+  system: "geonorge"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_DOK.Arealanalyse.demonstrator"
+  title: "Security Champion DOK.Arealanalyse.demonstrator"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "dagolav"
+  children:
+  - "resource:DOK.Arealanalyse.demonstrator"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "DOK.Arealanalyse.demonstrator"
+  links:
+  - url: "https://github.com/kartverket/DOK.Arealanalyse.demonstrator"
+    title: "DOK.Arealanalyse.demonstrator på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_DOK.Arealanalyse.demonstrator"
+  dependencyOf:
+  - "component:DOK.Arealanalyse.demonstrator"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: `
- `repo_types: [Experiment]`
- `platforms: [PUBLIC_CLOUD (Azure)]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.